### PR TITLE
Token based authentication

### DIFF
--- a/cmd/golinks/auth.go
+++ b/cmd/golinks/auth.go
@@ -14,7 +14,7 @@ import (
 
 // AuthManagerConfig defines the auth provider config.
 type AuthManagerConfig struct {
-	TokenExpieration int    `conf:"default:30;usage:token expiration time in day"`
+	TokenExpieration int    `conf:"default:30"` // token expiration time in day
 	TokenSecret      string `conf:"default:_golinks_jwt_token_secret_"`
 
 	NoAuth struct {

--- a/cmd/golinks/link.go
+++ b/cmd/golinks/link.go
@@ -1,4 +1,4 @@
-package main // nolint: dupl
+package main
 
 import (
 	"strings"

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.13
 require (
 	cloud.google.com/go v0.55.0 // indirect
 	contrib.go.opencensus.io/exporter/jaeger v0.2.0
+	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/gin-gonic/gin v1.6.2
 	github.com/gobuffalo/envy v1.9.0 // indirect
 	github.com/gobuffalo/packd v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -51,6 +51,8 @@ github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwc
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
+github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=

--- a/internal/api/middlewares/ctx-keys.go
+++ b/internal/api/middlewares/ctx-keys.go
@@ -1,7 +1,0 @@
-package middlewares
-
-// keys for values to save in gin.Context.
-const (
-	userKey   = "golinks.middlewares.auth_user"
-	getOrgKey = "golinks.middlewares.auth_get_org"
-)

--- a/internal/api/middlewares/keys.go
+++ b/internal/api/middlewares/keys.go
@@ -1,0 +1,12 @@
+package middlewares
+
+// keys for values to save in gin.Context.
+const (
+	getUserKey = "golinks.middlewares.auth_get_user"
+	getOrgKey  = "golinks.middlewares.auth_get_org"
+)
+
+// keys for values to save in cookies.
+const (
+	tokenCookieKey = "GOLINKS_TOKEN"
+)

--- a/internal/auth/errors.go
+++ b/internal/auth/errors.go
@@ -4,7 +4,14 @@ import "errors"
 
 // Exported errors.
 var (
-	ErrNotFound   = errors.New("not found")
+	ErrBadParams     = errors.New("bad parameters")
+	ErrInternalError = errors.New("internal error")
+	ErrNotFound      = errors.New("not found")
+
 	ErrStoreError = errors.New("internal store error")
-	ErrBadParams  = errors.New("bad parameters")
+	ErrOrgExists  = errors.New("org already exists")
+	ErrUserExists = errors.New("user already token")
+
+	ErrInvalidToken = errors.New("invalid token")
+	ErrTokenExpired = errors.New("token expired")
 )

--- a/internal/auth/interfaces.go
+++ b/internal/auth/interfaces.go
@@ -20,4 +20,9 @@ type Provider interface {
 	GetOrgUsers(ctx context.Context, name string) ([]string, error)
 	SetOrg(ctx context.Context, org Organization) error
 	DeleteOrg(ctx context.Context, name string) error
+
+	// tokens
+	GetToken(ctx context.Context, token string) (Token, error)
+	SetToken(ctx context.Context, token Token) error
+	DeleteToken(ctx context.Context, token string) error
 }

--- a/internal/auth/manager.go
+++ b/internal/auth/manager.go
@@ -1,0 +1,228 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+)
+
+// Config defines the auth manager config.
+type Config struct {
+	Provider         Provider
+	TokenExpieration time.Duration
+	TokenSecret      []byte
+}
+
+// New returns an auth manager with provider.
+func New(config Config) *Manager {
+	return &Manager{
+		Provider:         config.Provider,
+		TokenExpieration: config.TokenExpieration,
+		TokenSecret:      config.TokenSecret,
+	}
+}
+
+// Manager manages the authentication.
+type Manager struct {
+	Provider
+	TokenExpieration time.Duration
+	TokenSecret      []byte
+}
+
+// RegisterUser creates the user, ensuring the user does not exist and the org
+// does exist if user.Organization is not empty.
+func (m *Manager) RegisterUser(ctx context.Context, user User) (err error) {
+	var exists bool
+	exists, err = m.IsUserExists(ctx, user.Email)
+	if err != nil {
+		err = fmt.Errorf("failed to get user exists. %w", err)
+		return
+	}
+	if exists {
+		err = ErrUserExists
+		return
+	}
+	if user.Organization != "" {
+		exists, err = m.IsOrgExists(ctx, user.Organization)
+		if err != nil {
+			err = fmt.Errorf("failed to get org exists. %w", err)
+			return
+		}
+		if !exists {
+			err = fmt.Errorf("org not found. %w", ErrNotFound)
+			return
+		}
+	}
+	return m.SetUser(ctx, user)
+}
+
+// RegisterOrg creates the org.
+func (m *Manager) RegisterOrg(ctx context.Context, org Organization) (
+	err error) {
+	var exists bool
+	exists, err = m.IsOrgExists(ctx, org.Name)
+	if err != nil {
+		err = fmt.Errorf("failed to get org exists. %w", err)
+		return
+	}
+	if exists {
+		err = ErrOrgExists
+		return
+	}
+	if org.AdminEmail != "" {
+		exists, err = m.IsUserExists(ctx, org.AdminEmail)
+		if err != nil {
+			err = fmt.Errorf("failed to get admin exists. %w", err)
+			return
+		}
+		if !exists {
+			err = fmt.Errorf("admin user not found. %w", ErrNotFound)
+			return
+		}
+	}
+	// create org.
+	err = m.SetOrg(ctx, org)
+	if err != nil {
+		err = fmt.Errorf("%v;%w", err, ErrStoreError)
+	}
+	return
+}
+
+// RegisterOrgWithAdmin creates the org and the admin user.
+func (m *Manager) RegisterOrgWithAdmin(
+	ctx context.Context, org Organization, admin User) (err error) {
+	// check parameters
+	if org.AdminEmail != admin.Email {
+		err = ErrBadParams
+		return
+	}
+	// check if org or user exists
+	var exists bool
+	exists, err = m.IsOrgExists(ctx, org.Name)
+	if err != nil {
+		err = fmt.Errorf("failed to get org exists. %w", err)
+		return
+	}
+	if exists {
+		err = ErrOrgExists
+		return
+	}
+	exists, err = m.IsUserExists(ctx, admin.Email)
+	if err != nil {
+		err = fmt.Errorf("failed to get admin exists. %w", err)
+		return
+	}
+	if exists {
+		err = ErrUserExists
+		return
+	}
+	// create org and user.
+	err = m.SetOrg(ctx, org)
+	if err != nil {
+		err = fmt.Errorf("%v;%w", err, ErrStoreError)
+		return
+	}
+	err = m.SetUser(ctx, admin)
+	if err != nil {
+		err = fmt.Errorf("%v;%w", err, ErrStoreError)
+		// best effort to delete org
+		_ = m.DeleteOrg(ctx, org.Name)
+	}
+	return
+}
+
+// SetUserOrg sets the org of user with email.
+func (m *Manager) SetUserOrg(ctx context.Context, email, org string) error {
+	user, err := m.GetUser(ctx, email)
+	if err != nil {
+		return fmt.Errorf("user not found. %w", err)
+	}
+	if user.Organization == org {
+		return nil
+	}
+	_, err = m.GetOrg(ctx, org)
+	if err != nil {
+		return fmt.Errorf("org not found. %w", err)
+	}
+	user.Organization = org
+	return m.SetUser(ctx, user)
+}
+
+// IsUserExists returns if the user exists.
+func (m *Manager) IsUserExists(ctx context.Context, email string) (
+	exists bool, err error) {
+	_, err = m.GetUser(ctx, email)
+	if err == nil {
+		exists = true
+		return
+	}
+	if errors.Is(err, ErrNotFound) {
+		exists = false
+		err = nil
+		return
+	}
+	return
+}
+
+// IsOrgExists returns if the org exists.
+func (m *Manager) IsOrgExists(ctx context.Context, org string) (
+	exists bool, err error) {
+	_, err = m.GetOrg(ctx, org)
+	if err == nil {
+		exists = true
+		return
+	}
+	if errors.Is(err, ErrNotFound) {
+		exists = false
+		err = nil
+		return
+	}
+	return
+}
+
+// Login verify the user's email, password and returns the access token.
+func (m *Manager) Login(ctx context.Context, email string, password string) (
+	token *Token, err error) {
+	var user User
+	user, err = m.Provider.GetUser(ctx, email)
+	if err != nil {
+		return
+	}
+	token, err = NewToken(user, m.TokenSecret, m.TokenExpieration)
+	if err != nil {
+		return
+	}
+	err = m.SetToken(ctx, *token)
+	if err != nil {
+		token = nil
+	}
+	return
+}
+
+// Verify verifies the access token.
+func (m *Manager) Verify(ctx context.Context, tokenStr string) (
+	claims *TokenClaims, err error) {
+	var token Token
+	token, err = m.GetToken(ctx, tokenStr)
+	if err != nil {
+		if errors.Is(err, ErrNotFound) {
+			err = ErrInvalidToken
+			return
+		}
+		return
+	}
+	claims, err = verifyToken(token.JWT, m.TokenSecret)
+	if err != nil {
+		return
+	}
+	if claims.ExpiredAt < time.Now().Unix() {
+		err = ErrTokenExpired
+	}
+	return
+}
+
+// Logout deletes the access token.
+func (m *Manager) Logout(ctx context.Context, token string) (err error) {
+	return m.DeleteToken(ctx, token)
+}

--- a/internal/auth/manager_test.go
+++ b/internal/auth/manager_test.go
@@ -6,11 +6,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	. "github.com/haostudio/golinks/internal/auth"
 	"github.com/haostudio/golinks/internal/auth/kv"
 	"github.com/haostudio/golinks/internal/encoding/gob"
 	"github.com/haostudio/golinks/internal/kv/memory"
-	"github.com/stretchr/testify/require"
 )
 
 func TestManagerRegisterUser(t *testing.T) {

--- a/internal/auth/manager_test.go
+++ b/internal/auth/manager_test.go
@@ -1,0 +1,69 @@
+package auth_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	. "github.com/haostudio/golinks/internal/auth"
+	"github.com/haostudio/golinks/internal/auth/kv"
+	"github.com/haostudio/golinks/internal/encoding/gob"
+	"github.com/haostudio/golinks/internal/kv/memory"
+	"github.com/stretchr/testify/require"
+)
+
+func TestManagerRegisterUser(t *testing.T) {
+	{
+		manager := testManager()
+		user, err := NewUser("email@test.com", "test_pwd", "")
+		require.NoError(t, err)
+		require.NoError(t, manager.RegisterUser(context.Background(), *user))
+	}
+	{
+		manager := testManager()
+		user, err := NewUser("email@test.com", "test_pwd", "org")
+		require.NoError(t, err)
+		err = manager.RegisterUser(context.Background(), *user)
+		require.True(t, errors.Is(err, ErrNotFound))
+		org := Organization{
+			Name:       "org",
+			AdminEmail: "xxx",
+		}
+		require.NoError(t, manager.SetOrg(context.Background(), org))
+		require.NoError(t, manager.RegisterUser(context.Background(), *user))
+	}
+}
+
+func TestManagerRegisterOrg(t *testing.T) {
+	{
+		manager := testManager()
+		org := Organization{
+			Name:       "org",
+			AdminEmail: "",
+		}
+		require.NoError(t, manager.RegisterOrg(context.Background(), org))
+	}
+	{
+		manager := testManager()
+		org := Organization{
+			Name:       "org",
+			AdminEmail: "email@test.com",
+		}
+		err := manager.RegisterOrg(context.Background(), org)
+		require.True(t, errors.Is(err, ErrNotFound))
+
+		user, err := NewUser("email@test.com", "test_pwd", "org")
+		require.NoError(t, err)
+		require.NoError(t, manager.SetUser(context.Background(), *user))
+		require.NoError(t, manager.RegisterOrg(context.Background(), org))
+	}
+}
+
+func testManager() *Manager {
+	return New(Config{
+		Provider:         kv.New(memory.New().In("auth"), gob.New()),
+		TokenExpieration: 1 * 24 * time.Hour,
+		TokenSecret:      []byte("token_secret"),
+	})
+}

--- a/internal/auth/token.go
+++ b/internal/auth/token.go
@@ -1,0 +1,94 @@
+package auth
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/dgrijalva/jwt-go"
+)
+
+// NewToken generates a new signed JWT token.
+func NewToken(user User, secret []byte, expiration time.Duration) (
+	token *Token, err error) {
+	jwt, err := genToken(tokenParams{
+		User:      user,
+		IssuedAt:  time.Now(),
+		ExpiredAt: time.Now().Add(expiration),
+		Secret:    secret,
+	})
+	if err != nil {
+		err = fmt.Errorf("%v; %w", err, ErrInternalError)
+		return
+	}
+	token = &Token{
+		JWT: jwt,
+	}
+	return
+}
+
+// Token defines the token model.
+type Token struct {
+	JWT string
+}
+
+type tokenParams struct {
+	User      User
+	IssuedAt  time.Time
+	ExpiredAt time.Time
+	Secret    []byte
+}
+
+// TokenClaims defines the token claims struct.
+type TokenClaims struct {
+	Email     string `json:"email"`
+	Org       string `json:"org"`
+	IssuedAt  int64  `json:"issued_at"`
+	ExpiredAt int64  `json:"expired_at"`
+}
+
+// Valid implements the JWT interface.
+func (c *TokenClaims) Valid() error {
+	if c.ExpiredAt < time.Now().Unix() {
+		return ErrTokenExpired
+	}
+	return nil
+}
+
+func genToken(params tokenParams) (string, error) {
+	jwtToken := jwt.NewWithClaims(jwt.SigningMethodHS256, &TokenClaims{
+		Email:     params.User.Email,
+		Org:       params.User.Organization,
+		IssuedAt:  params.IssuedAt.Unix(),
+		ExpiredAt: params.ExpiredAt.Unix(),
+	})
+	return jwtToken.SignedString(params.Secret)
+}
+
+func verifyToken(tokenStr string, secret []byte) (
+	claims *TokenClaims, err error) {
+	claims = &TokenClaims{}
+	token, err := jwt.ParseWithClaims(tokenStr, claims,
+		func(token *jwt.Token) (interface{}, error) {
+			// validate the alg
+			if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
+				return nil, fmt.Errorf("unexpected signing method: %v",
+					token.Header["alg"])
+			}
+			return secret, nil
+		})
+
+	if err != nil {
+		err = fmt.Errorf("%v; %w", err, ErrInvalidToken)
+		return
+	}
+	if !token.Valid {
+		err = ErrInvalidToken
+		return
+	}
+	claims, ok := token.Claims.(*TokenClaims)
+	if !ok {
+		err = ErrInvalidToken
+		return
+	}
+	return
+}

--- a/internal/auth/token_test.go
+++ b/internal/auth/token_test.go
@@ -1,0 +1,31 @@
+package auth
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestToken(t *testing.T) {
+	secret := []byte("test secret")
+	now := time.Now()
+	params := tokenParams{
+		User: User{
+			Email:        "hi",
+			PasswordHash: []byte("how are you"),
+			Organization: "hello",
+		},
+		IssuedAt:  now,
+		ExpiredAt: now.Add(1),
+		Secret:    secret,
+	}
+	token, err := genToken(params)
+	require.NoError(t, err)
+	claims, err := verifyToken(token, secret)
+	require.NoError(t, err)
+	require.Equal(t, "hi", claims.Email)
+	require.Equal(t, "hello", claims.Org)
+	require.Equal(t, now.Unix(), claims.IssuedAt)
+	require.Equal(t, now.Add(1).Unix(), claims.ExpiredAt)
+}

--- a/internal/auth/traced/provider.go
+++ b/internal/auth/traced/provider.go
@@ -80,6 +80,26 @@ func (p *provider) DeleteOrg(ctx context.Context, name string) error {
 	return p.provider.DeleteOrg(ctx, name)
 }
 
+// tokens
+func (p *provider) GetToken(ctx context.Context, tokenStr string) (
+	token auth.Token, err error) {
+	ctx, span := p.getSpan(ctx, "provider.GetToken")
+	defer span.End()
+	return p.provider.GetToken(ctx, tokenStr)
+}
+
+func (p *provider) SetToken(ctx context.Context, token auth.Token) error {
+	ctx, span := p.getSpan(ctx, "provider.SetToken")
+	defer span.End()
+	return p.provider.SetToken(ctx, token)
+}
+
+func (p *provider) DeleteToken(ctx context.Context, token string) error {
+	ctx, span := p.getSpan(ctx, "provider.DeleteToken")
+	defer span.End()
+	return p.provider.DeleteToken(ctx, token)
+}
+
 func (p *provider) String() string {
 	return fmt.Sprintf("traced(%s)", p.provider)
 }

--- a/internal/service/golinks/golinkstest/server.go
+++ b/internal/service/golinks/golinkstest/server.go
@@ -1,8 +1,11 @@
 package golinkstest
 
 import (
+	"time"
+
 	"github.com/gin-gonic/gin"
 
+	"github.com/haostudio/golinks/internal/auth"
 	authkv "github.com/haostudio/golinks/internal/auth/kv"
 	"github.com/haostudio/golinks/internal/encoding/gob"
 	"github.com/haostudio/golinks/internal/kv/memory"
@@ -27,7 +30,12 @@ func NewTestServer() service.Service {
 	}
 	conf.Auth.Enabled = true
 	conf.Auth.DefaultOrg = ""
-	conf.Auth.Provider = authProvider
+	conf.Auth.Manager = auth.New(auth.Config{
+		Provider:         authProvider,
+		TokenExpieration: 1 * 24 * time.Hour,
+		TokenSecret:      []byte("token_secret"),
+	})
+
 	gin.Default()
 
 	return golinks.New(conf)

--- a/internal/service/golinks/modules/authapi/authapi.go
+++ b/internal/service/golinks/modules/authapi/authapi.go
@@ -9,8 +9,8 @@ import (
 )
 
 // Register registers auth endpoints in router.
-func Register(router gin.IRouter, provider auth.Provider) {
-	module := New(provider)
+func Register(router gin.IRouter, manager *auth.Manager) {
+	module := New(manager)
 	router.GET(
 		fmt.Sprintf("/:%s", module.PathParamOrgKey()),
 		module.GetOrg,

--- a/internal/service/golinks/modules/authweb/authweb.go
+++ b/internal/service/golinks/modules/authweb/authweb.go
@@ -25,7 +25,7 @@ func Register(router gin.IRouter, conf Config) {
 	// org/manage
 	{
 		manageRouter := router.Group("manage")
-		manageRouter.Use(middlewares.Auth(conf.Provider))
+		manageRouter.Use(middlewares.Auth(conf.Manager))
 		manageRouter.GET("", module.SetOrgUser())
 		manageRouter.POST("", module.HandleSetOrgUserForm)
 	}

--- a/internal/service/golinks/services.go
+++ b/internal/service/golinks/services.go
@@ -32,7 +32,7 @@ type Config struct {
 	Auth    struct {
 		Enabled    bool
 		DefaultOrg string        // default org for Auth.Enabled = false
-		Provider   auth.Provider // provider for Auth.Enabled = true
+		Manager    *auth.Manager // provider for Auth.Enabled = true
 	}
 	LinkStore link.Store
 }
@@ -83,7 +83,7 @@ func (s *svc) buildRouter() http.Handler {
 	// Log server config
 	logger.Info("server link store: %s", s.LinkStore)
 	if s.Auth.Enabled {
-		logger.Info("server auth provider: %s", s.Auth.Provider)
+		logger.Info("server auth provider: %s", s.Auth.Manager)
 	} else {
 		logger.Warn("server auth disabled")
 		logger.Warn("server default org: %s", s.Auth.DefaultOrg)
@@ -123,7 +123,7 @@ func (s *svc) buildRouter() http.Handler {
 	// Link module
 	lnGroup := router.Group("links")
 	if s.Auth.Enabled {
-		lnGroup.Use(middlewares.Auth(s.Auth.Provider))
+		lnGroup.Use(middlewares.Auth(s.Auth.Manager))
 	} else {
 		lnGroup.Use(middlewares.NoAuth(s.Auth.DefaultOrg))
 	}
@@ -136,15 +136,15 @@ func (s *svc) buildRouter() http.Handler {
 	if s.Auth.Enabled {
 		orgGroup := router.Group("org")
 		authweb.Register(orgGroup, authweb.Config{
-			Traced:   s.Traced,
-			Provider: s.Auth.Provider,
+			Traced:  s.Traced,
+			Manager: s.Auth.Manager,
 		})
 	}
 
 	// Link api module
 	lnAPIGroup := router.Group("api/links")
 	if s.Auth.Enabled {
-		lnAPIGroup.Use(middlewares.Auth(s.Auth.Provider))
+		lnAPIGroup.Use(middlewares.Auth(s.Auth.Manager))
 	} else {
 		lnAPIGroup.Use(middlewares.NoAuth(s.Auth.DefaultOrg))
 	}
@@ -153,8 +153,8 @@ func (s *svc) buildRouter() http.Handler {
 	// Auth module
 	if s.Auth.Enabled {
 		authGroup := router.Group("api/orgs")
-		authGroup.Use(middlewares.Auth(s.Auth.Provider))
-		authapi.Register(authGroup, s.Auth.Provider)
+		authGroup.Use(middlewares.Auth(s.Auth.Manager))
+		authapi.Register(authGroup, s.Auth.Manager)
 	}
 
 	// nolint: godox
@@ -162,7 +162,7 @@ func (s *svc) buildRouter() http.Handler {
 	// Use redirect handler by default.
 	var noRoute []gin.HandlerFunc
 	if s.Auth.Enabled {
-		noRoute = append(noRoute, middlewares.Auth(s.Auth.Provider))
+		noRoute = append(noRoute, middlewares.Auth(s.Auth.Manager))
 		noRoute = append(noRoute, middlewares.OrgRateLimit(5, time.Second))
 	} else {
 		noRoute = append(noRoute, middlewares.NoAuth(s.Auth.DefaultOrg))

--- a/internal/service/golinks/services.go
+++ b/internal/service/golinks/services.go
@@ -120,10 +120,10 @@ func (s *svc) buildRouter() http.Handler {
 		AuthEnabled: s.Auth.Enabled,
 	})
 
-	// Link module
+	// Link web module
 	lnGroup := router.Group("links")
 	if s.Auth.Enabled {
-		lnGroup.Use(middlewares.Auth(s.Auth.Manager))
+		lnGroup.Use(middlewares.AuthHTTPBasicAuth(s.Auth.Manager))
 	} else {
 		lnGroup.Use(middlewares.NoAuth(s.Auth.DefaultOrg))
 	}
@@ -144,7 +144,7 @@ func (s *svc) buildRouter() http.Handler {
 	// Link api module
 	lnAPIGroup := router.Group("api/links")
 	if s.Auth.Enabled {
-		lnAPIGroup.Use(middlewares.Auth(s.Auth.Manager))
+		lnAPIGroup.Use(middlewares.AuthSimple401(s.Auth.Manager))
 	} else {
 		lnAPIGroup.Use(middlewares.NoAuth(s.Auth.DefaultOrg))
 	}
@@ -153,7 +153,7 @@ func (s *svc) buildRouter() http.Handler {
 	// Auth module
 	if s.Auth.Enabled {
 		authGroup := router.Group("api/orgs")
-		authGroup.Use(middlewares.Auth(s.Auth.Manager))
+		authGroup.Use(middlewares.AuthHTTPBasicAuth(s.Auth.Manager))
 		authapi.Register(authGroup, s.Auth.Manager)
 	}
 
@@ -162,7 +162,7 @@ func (s *svc) buildRouter() http.Handler {
 	// Use redirect handler by default.
 	var noRoute []gin.HandlerFunc
 	if s.Auth.Enabled {
-		noRoute = append(noRoute, middlewares.Auth(s.Auth.Manager))
+		noRoute = append(noRoute, middlewares.AuthHTTPBasicAuth(s.Auth.Manager))
 		noRoute = append(noRoute, middlewares.OrgRateLimit(5, time.Second))
 	} else {
 		noRoute = append(noRoute, middlewares.NoAuth(s.Auth.DefaultOrg))


### PR DESCRIPTION
- Use `auth.Manage` instead of `auth.Provider`
- Use `GOLINKS_TOKEN` in cookie instead of checking email and password for authorization